### PR TITLE
Update to Xenial in Travis 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,1 +1,13 @@
 language: rust
+dist: xenial
+env:
+  - DOCKER_COMPOSE_VERSION=1.24.0
+
+before_install:
+  - sudo rm /usr/local/bin/docker-compose
+  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
+  - chmod +x docker-compose
+  - sudo mv docker-compose /usr/local/bin
+
+script:
+  - docker-compose up rpgffi10

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,30 +1,29 @@
 FROM ubuntu:xenial
 MAINTAINER Drazen Urch <github@drazenur.ch>
 
-ARG PG_VER=10
-ARG RUST_VER=1.13.0
-
 ENV USER root
+ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
+    ca-certificates \
     software-properties-common \
     python-software-properties \
     wget
-RUN add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" && \
-    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -  && \
+RUN wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -  && \
+    add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" && \
     apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    apt-get install -y --no-install-recommends \
         build-essential \
-        ca-certificates \
         curl \
         musl-tools \
         clang \
         libclang-dev \
         git \
         libssl-dev \
-        bc \
-        postgresql-server-dev-${PG_VER}
+        bc
+
+ARG RUST_VER=1.33.0
 RUN curl -sO https://static.rust-lang.org/dist/rust-${RUST_VER}-x86_64-unknown-linux-gnu.tar.gz && \
     tar -xzf rust-${RUST_VER}-x86_64-unknown-linux-gnu.tar.gz && \
     ./rust-${RUST_VER}-x86_64-unknown-linux-gnu/install.sh --without=rust-docs && \
@@ -33,8 +32,10 @@ RUN curl -sO https://static.rust-lang.org/dist/rust-${RUST_VER}-x86_64-unknown-l
     ./rust-std-${RUST_VER}-x86_64-unknown-linux-musl/install.sh --without=rust-docs
 RUN cargo install bindgen
 
-RUN DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y curl && \
-    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
+ARG PG_VER=10
+RUN apt-get install -y --no-install-recommends postgresql-server-dev-${PG_VER} && \
+    apt-get remove --purge -y curl && \
+    apt-get autoremove -y
 RUN rm -rf \
     rust-std-${RUST_VER}-x86_64-unknown-linux-musl \
     rust-${RUST_VER}-x86_64-unknown-linux-gnu \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,11 +8,13 @@ services:
       dockerfile: Dockerfile
       args:
         - PG_VER=10
-        - RUST_VER=1.20.0
+        - RUST_VER=1.33.0
     volumes:
       - .:/source
     working_dir: /source
-    command: util/generate_bindings
+    command: >
+      sh -c "util/generate_bindings &&
+             cargo test --verbose"
   rpgffi96:
     extends:
       service: rpgffi10
@@ -37,4 +39,3 @@ services:
     build:
       args:
         - PG_VER=9.3
-


### PR DESCRIPTION
I started this by just trying to unify the various versions of OS being used, namely
`Dockerfile` (`xenial`) and TravisCI (`trusty` by default).  I then moved to upgrade
`rust` to the latest `stable` (`1.33.0`).

Once that was done, I wanted TravisCI to test that whichever bindings were getting
generated, were the ones being tested. As it were, one could generate `src/pg<version>.rs`
and `src/lib.rs` and then the TravisCI test would fail due to running it all in `trusty`
with slightly different versions of the software.

End result is that TravisCI now should generate and test against those same generated. If
we want to ensure that the ones TravisCI generates are no different, we could add a step
to TravisCI to check that no file in `src/` has been modified.